### PR TITLE
Update release workflow github token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           node-version: '14'
           registry-url: 'https://npm.pkg.github.com'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
       
       - name: Install module dependencies
         run: yarn


### PR DESCRIPTION
The PR updates the `publish` workflow github token to an organization created secret because available `WORKFLOW_TOKEN`