### PR TITLE
Add component multiprops on new line rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "src",
   "scripts": {
     "changelog": "echo \"$(github-changelog-generator --future-release=v$npm_package_version)\n$(tail -n +2 CHANGELOG.md)\" > CHANGELOG.md",
-    "lint": "eslint --config src/index.js src/index.js test/index.test.js",
+    "lint": "eslint --config src/index.js test/index.test.js",
     "lint-staged": "lint-staged",
     "test": "jest",
     "version": "npm run changelog && git add -A CHANGELOG.md"

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ module.exports = {
       props: 'always'
     }],
     'react/jsx-curly-spacing': 'error',
+    'react/jsx-first-prop-new-line': ['error', 'multiline-multiprop'],
     'react/jsx-indent': ['error', 2],
     'react/jsx-indent-props': ['error', 2],
     'react/jsx-key': 'error',

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -13,6 +13,7 @@ Array [
   "react-hooks/rules-of-hooks",
   "react/jsx-curly-brace-presence",
   "react/jsx-no-literals",
+  "react/jsx-first-prop-new-line",
   "react/jsx-tag-spacing",
   "react/jsx-tag-spacing",
   "react/jsx-tag-spacing",

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -51,6 +51,16 @@ const NoLiterals = () => (
 
 noop(NoLiterals);
 
+// `react/jsx-first-prop-new-line`.
+const FirstPropNewLineMultiprops = () => (
+  <div
+    biz={'baz'}
+    foo={'bar'}
+  />
+);
+
+noop(FirstPropNewLineMultiprops);
+
 // `react/jsx-tag-spacing`.
 const TagSpacing = () => (
   <div />

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -56,6 +56,15 @@ const NoLiterals = () => (
 
 noop(NoLiterals);
 
+// `react/jsx-first-prop-new-line`.
+const FirstPropNewLineMultiprops = () => (
+  <div biz={'baz'}
+    foo={'bar'}
+  />
+);
+
+noop(FirstPropNewLineMultiprops);
+
 // `react/jsx-tag-spacing`.
 const TagSpacingAfterOpening = () => (
   < div />


### PR DESCRIPTION
This PR adds `react/jsx-first-prop-new-line` rule for multiprop components.

https://user-images.githubusercontent.com/19315900/161303769-6c969ee8-4087-4ec9-a282-6ed90c1007de.mov


