### PR TITLE
Add new line between components rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ module.exports = {
     'react/jsx-indent-props': ['error', 2],
     'react/jsx-key': 'error',
     'react/jsx-max-props-per-line': 'error',
+    'react/jsx-newline': ['error', { prevent: false }],
     'react/jsx-no-duplicate-props': 'error',
     'react/jsx-no-literals': 'error',
     'react/jsx-no-undef': 'error',

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -12,6 +12,7 @@ Array [
   "react-hooks/rules-of-hooks",
   "react-hooks/rules-of-hooks",
   "react/jsx-curly-brace-presence",
+  "react/jsx-newline",
   "react/jsx-no-literals",
   "react/jsx-first-prop-new-line",
   "react/jsx-tag-spacing",

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -42,6 +42,17 @@ const CurlyBracePresence = () => (
 
 noop(CurlyBracePresence);
 
+// `react/jsx-newline`.
+const NewLineBetweenComponents = () => (
+  <div>
+    <div />
+
+    <div />
+  </div>
+);
+
+noop(NewLineBetweenComponents);
+
 // `react/jsx-no-literals`.
 const NoLiterals = () => (
   <div>

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -47,6 +47,16 @@ const CurlyBracePresence = () => (
 
 noop(CurlyBracePresence);
 
+// `react/jsx-newline`.
+const NewLineBetweenComponents = () => (
+  <div>
+    <div />
+    <div />
+  </div>
+);
+
+noop(NewLineBetweenComponents);
+
 // `react/jsx-no-literals`.
 const NoLiterals = () => (
   <div>


### PR DESCRIPTION
This PR adds `react/jsx-newline`.

https://user-images.githubusercontent.com/19315900/161305989-6003e9be-60da-47e5-8045-f0c2b502ad2c.mov
