### PR TITLE
Add closing bracket location rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ module.exports = {
     'new-cap': ['error', { capIsNewExceptions: ['BigNumber'] }],
     'react/display-name': 'error',
     'react/jsx-boolean-value': 'error',
-    'react/jsx-closing-bracket-location': 'error',
+    'react/jsx-closing-bracket-location': ['error', 'line-aligned'],
     'react/jsx-curly-brace-presence': ['error', {
       children: 'ignore',
       props: 'always'

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -11,6 +11,7 @@ Array [
   "react-hooks/rules-of-hooks",
   "react-hooks/rules-of-hooks",
   "react-hooks/rules-of-hooks",
+  "react/jsx-closing-bracket-location",
   "react/jsx-curly-brace-presence",
   "react/jsx-newline",
   "react/jsx-no-literals",

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -63,6 +63,7 @@ const NoLiterals = () => (
 noop(NoLiterals);
 
 // `react/jsx-first-prop-new-line`.
+// `react/jsx-closing-bracket-location`.
 const FirstPropNewLineMultiprops = () => (
   <div
     biz={'baz'}

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -40,6 +40,15 @@ function notHook() {
 
 noop(RulesOfHooks, notHook);
 
+// `react/jsx-closing-bracket-location`.
+const ClosingBracketLocation = () => (
+  <div
+    firstName={'foo'}
+    lastName={'bar'} />
+);
+
+noop(ClosingBracketLocation);
+
 // `react/jsx-curly-brace-presence`.
 const CurlyBracePresence = () => (
   <div foo='bar' />


### PR DESCRIPTION
This PR adds `react/jsx-closing-bracket-location` - `line-aligned`

https://user-images.githubusercontent.com/44649923/163830483-21b58a21-62ab-44bb-804d-72576050631b.mov